### PR TITLE
导包改为相对路径

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1,16 +1,17 @@
 package cmd
 
 import (
-	"net"
 	"io"
 	"log"
-	"golang.org/x/net/proxy"
 	"math/rand"
-	"testing"
+	"net"
 	"reflect"
-	"github.com/gwuhaolin/lightsocks/core"
-	"github.com/gwuhaolin/lightsocks/server"
-	"github.com/gwuhaolin/lightsocks/local"
+	"testing"
+
+	"../core"
+	"../local"
+	"../server"
+	"golang.org/x/net/proxy"
 )
 
 const (

--- a/cmd/lightsocks-local/main.go
+++ b/cmd/lightsocks-local/main.go
@@ -7,18 +7,36 @@ import (
 
 	"flag"
 
+	"../../cmd"
 	"../../core"
 	"../../local"
+)
+
+const (
+	DefaultListenAddr = ":7448"
 )
 
 var version = "master"
 
 func main() {
 	log.SetFlags(log.Lshortfile)
+
 	passwd := flag.String("password", "", "")
 	rmt := flag.String("remote", "", "")
-	listen := flag.String("listen", ":7448", "")
+	listen := flag.String("listen", DefaultListenAddr, "")
 	flag.Parse()
+
+	if *rmt == "" || *passwd == "" {
+		config := &cmd.Config{
+			ListenAddr: DefaultListenAddr,
+		}
+		config.ReadConfig()
+		config.SaveConfig()
+
+		*rmt = config.RemoteAddr
+		*passwd = config.Password
+		*listen = config.ListenAddr
+	}
 
 	password, err := core.ParsePassword(*passwd)
 	if err != nil {

--- a/cmd/lightsocks-local/main.go
+++ b/cmd/lightsocks-local/main.go
@@ -1,39 +1,34 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net"
-	"fmt"
-	"github.com/gwuhaolin/lightsocks/local"
-	"github.com/gwuhaolin/lightsocks/cmd"
-	"github.com/gwuhaolin/lightsocks/core"
-)
 
-const (
-	DefaultListenAddr = ":7448"
+	"flag"
+
+	"../../core"
+	"../../local"
 )
 
 var version = "master"
 
 func main() {
 	log.SetFlags(log.Lshortfile)
+	passwd := flag.String("password", "", "")
+	rmt := flag.String("remote", "", "")
+	listen := flag.String("listen", ":7448", "")
+	flag.Parse()
 
-	var err error
-	config := &cmd.Config{
-		ListenAddr: DefaultListenAddr,
-	}
-	config.ReadConfig()
-	config.SaveConfig()
-
-	password, err := core.ParsePassword(config.Password)
+	password, err := core.ParsePassword(*passwd)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	listenAddr, err := net.ResolveTCPAddr("tcp", config.ListenAddr)
+	listenAddr, err := net.ResolveTCPAddr("tcp", *listen)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	remoteAddr, err := net.ResolveTCPAddr("tcp", config.RemoteAddr)
+	remoteAddr, err := net.ResolveTCPAddr("tcp", *rmt)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/lightsocks-server/main.go
+++ b/cmd/lightsocks-server/main.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"net"
 	"fmt"
-	"github.com/gwuhaolin/lightsocks/server"
-	"github.com/gwuhaolin/lightsocks/cmd"
-	"github.com/gwuhaolin/lightsocks/core"
+	"../../server"
+	"../../cmd"
+	"../../core"
 	"github.com/phayes/freeport"
 )
 

--- a/local/local.go
+++ b/local/local.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"log"
 	"time"
-	"github.com/gwuhaolin/lightsocks/core"
+	"../core"
 )
 
 type LsLocal struct {

--- a/server/server.go
+++ b/server/server.go
@@ -1,10 +1,11 @@
 package server
 
 import (
-	"net"
 	"encoding/binary"
+	"net"
 	"time"
-	"github.com/gwuhaolin/lightsocks/core"
+
+	"../core"
 )
 
 type LsServer struct {
@@ -59,17 +60,17 @@ func (server *LsServer) handleConn(localConn *net.TCPConn) {
 	buf := make([]byte, 256)
 
 	/**
-	The localConn connects to the dstServer, and sends a ver
-   	identifier/method selection message:
-		   +----+----------+----------+
-                   |VER | NMETHODS | METHODS  |
-                   +----+----------+----------+
-                   | 1  |    1     | 1 to 255 |
-                   +----+----------+----------+
-	The VER field is set to X'05' for this ver of the protocol.  The
-   	NMETHODS field contains the number of method identifier octets that
-   	appear in the METHODS field.
-	 */
+		The localConn connects to the dstServer, and sends a ver
+	   	identifier/method selection message:
+			   +----+----------+----------+
+	                   |VER | NMETHODS | METHODS  |
+	                   +----+----------+----------+
+	                   | 1  |    1     | 1 to 255 |
+	                   +----+----------+----------+
+		The VER field is set to X'05' for this ver of the protocol.  The
+	   	NMETHODS field contains the number of method identifier octets that
+	   	appear in the METHODS field.
+	*/
 	// 第一个字段VER代表Socks的版本，Socks5默认为0x05，其固定长度为1个字节
 	_, err := server.DecodeRead(localConn, buf)
 	// 只支持版本5
@@ -78,25 +79,25 @@ func (server *LsServer) handleConn(localConn *net.TCPConn) {
 	}
 
 	/**
-	The dstServer selects from one of the methods given in METHODS, and
-   	sends a METHOD selection message:
+		The dstServer selects from one of the methods given in METHODS, and
+	   	sends a METHOD selection message:
 
-                         +----+--------+
-                         |VER | METHOD |
-                         +----+--------+
-                         | 1  |   1    |
-                         +----+--------+
-	 */
+	                         +----+--------+
+	                         |VER | METHOD |
+	                         +----+--------+
+	                         | 1  |   1    |
+	                         +----+--------+
+	*/
 	// 不需要验证，直接验证通过
 	server.EncodeWrite(localConn, []byte{0x05, 0x00})
 
 	/**
-	+----+-----+-------+------+----------+----------+
-        |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
-        +----+-----+-------+------+----------+----------+
-        | 1  |  1  | X'00' |  1   | Variable |    2     |
-        +----+-----+-------+------+----------+----------+
-	 */
+		+----+-----+-------+------+----------+----------+
+	        |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
+	        +----+-----+-------+------+----------+----------+
+	        | 1  |  1  | X'00' |  1   | Variable |    2     |
+	        +----+-----+-------+------+----------+----------+
+	*/
 
 	// CMD代表客户端请求的类型，值长度也是1个字节，有三种类型
 	// CONNECT X'01'
@@ -115,7 +116,7 @@ func (server *LsServer) handleConn(localConn *net.TCPConn) {
 	switch buf[3] {
 	case 0x01:
 		//	IP V4 address: X'01'
-		dIP = buf[4:4+net.IPv4len]
+		dIP = buf[4 : 4+net.IPv4len]
 	case 0x03:
 		//	DOMAINNAME: X'03'
 		ipAddr, err := net.ResolveIPAddr("ip", string(buf[5:n-2]))
@@ -125,7 +126,7 @@ func (server *LsServer) handleConn(localConn *net.TCPConn) {
 		dIP = ipAddr.IP
 	case 0x04:
 		//	IP V6 address: X'04'
-		dIP = buf[4:4+net.IPv6len]
+		dIP = buf[4 : 4+net.IPv6len]
 	default:
 		return
 	}
@@ -137,12 +138,12 @@ func (server *LsServer) handleConn(localConn *net.TCPConn) {
 	dstServer, err := net.DialTCP("tcp", nil, dstAddr)
 
 	/**
-	 +----+-----+-------+------+----------+----------+
-        |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
-        +----+-----+-------+------+----------+----------+
-        | 1  |  1  | X'00' |  1   | Variable |    2     |
-        +----+-----+-------+------+----------+----------+
-	 */
+		 +----+-----+-------+------+----------+----------+
+	        |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
+	        +----+-----+-------+------+----------+----------+
+	        | 1  |  1  | X'00' |  1   | Variable |    2     |
+	        +----+-----+-------+------+----------+----------+
+	*/
 	if err != nil {
 		return
 	} else {


### PR DESCRIPTION
解决了项目不在github.com/gwuhaolin/lightsocks下时不能编译的问题<br>
不过go中用相对路径似乎不是最佳实践，不能接受相对路径的话就直接把这个PR关了吧